### PR TITLE
Update runner-lib.ts

### DIFF
--- a/main-server/src/models/challenge.rs
+++ b/main-server/src/models/challenge.rs
@@ -21,10 +21,10 @@ impl Default for NewChallenge {
             )
             .to_string(),
             judge: concat!(
-                "(async function*(code: Code): AsyncGenerator<TestCase, FinalVerdict, undefined> {\n",
-                "  yield (await code.run(undefined)).assertEquals('Hello World!');\n",
+                "(async function*(context: Context): Challenge {\n",
+                "  yield (await context.run(undefined)).assertEquals('Hello World!');\n",
                 "  //Your code here\n",
-                "  return code.noFailures();\n",
+                "  return context.noFailures();\n",
                 "})"
             )
             .to_string(),

--- a/scripts/runner-lib.ts
+++ b/scripts/runner-lib.ts
@@ -2,16 +2,17 @@ export type PassState = 'Pass' | 'Fail' | 'Warning' | 'Info';
 export type ResultDisplay = { 'Diff': { expected: string, output: string } }
     | { 'Text': string }
     | { 'Run': { input?: string | undefined, output: string, error: string } };
+export type Challenge = AsyncGenerator<TestCase, FinalVerdict, undefined>;
 
 export class TestCase {
     name: string | undefined;
     pass: PassState;
     resultDisplay: ResultDisplay;
 
-    constructor(name: string | undefined, pass: PassState, resultDisplay: ResultDisplay) {
+    constructor(name: string | undefined, pass: PassState | boolean, resultDisplay: ResultDisplay | string) {
         this.name = name;
-        this.pass = pass;
-        this.resultDisplay = resultDisplay;
+        this.pass = pass === true ? 'Pass' : pass === false ? 'Fail' : pass;
+        this.resultDisplay = typeof resultDisplay === 'string' ? {Text: resultDisplay} : resultDisplay;
     }
 
     public setName(name: string): this {
@@ -46,11 +47,11 @@ export interface RunCompiledCodeResult extends RunCodeResult {
 }
 
 export class StringResult {
-    protected code: Code
+    protected context: Context
     public text: string
 
-    public constructor(code: Code, text: string) {
-        this.code = code;
+    public constructor(context: Context, text: string) {
+        this.context = context;
         this.text = text;
     }
 
@@ -66,13 +67,13 @@ export class StringResult {
                 }
             }
         );
-        this.code.testCases.push(testCase);
+        this.context.testCases.push(testCase);
         return testCase;
     }
 
     public assert(cb: (k: string) => TestCase): TestCase {
         const vestCase = cb(this.text);
-        this.code.testCases.push(vestCase);
+        this.context.testCases.push(vestCase);
         return vestCase
     }
 }
@@ -80,17 +81,17 @@ export class StringResult {
 export class RunResult extends StringResult {
     private stderr: string;
 
-    public constructor(code: Code, result: RunCodeResult) {
-        super(code, result.stdout);
+    public constructor(context: Context, result: RunCodeResult) {
+        super(context, result.stdout);
         this.stderr = result.stderr;
     }
 
     public error() {
-        return new StringResult(this.code, this.stderr);
+        return new StringResult(this.context, this.stderr);
     }
 }
 
-export class Code {
+export class Context {
     public code: string;
     private onRunCallback: (code: string, input: string | undefined) => Promise<RunCompiledCodeResult>;
     public testCases: TestCase[];

--- a/scripts/runner-lib.ts
+++ b/scripts/runner-lib.ts
@@ -151,3 +151,18 @@ export const eqIgnoreTrailingWhitespace = (a: string, b: string): boolean => {
     )
     return a_stripped == b_stripped
 }
+
+export function range(a: number, b?: number): number[] {
+    return b === undefined ? [...Array(a).keys()] : range(b - a).map(x => x + a);
+}
+
+export function rand(a: number, b?: number): number {
+    return b === undefined ? Math.floor(Math.random() * a) : rand(b - a) + a;
+}
+
+export function shuffle(array: unknown[]): void {
+    for (let i = array.length - 1; i >= 0; i--) {
+        const j = rand(i + 1);
+        [array[i], array[j]] = [array[j], array[i]];
+    }
+}

--- a/scripts/runner-lib.ts
+++ b/scripts/runner-lib.ts
@@ -9,10 +9,10 @@ export class TestCase {
     pass: PassState;
     resultDisplay: ResultDisplay;
 
-    constructor(name: string | undefined, pass: PassState | boolean, resultDisplay: ResultDisplay | string) {
+    constructor(name: string | undefined, pass: PassState, resultDisplay: ResultDisplay) {
         this.name = name;
-        this.pass = pass === true ? 'Pass' : pass === false ? 'Fail' : pass;
-        this.resultDisplay = typeof resultDisplay === 'string' ? {Text: resultDisplay} : resultDisplay;
+        this.pass = pass;
+        this.resultDisplay = resultDisplay;
     }
 
     public setName(name: string): this {


### PR DESCRIPTION
Some ideas to improve the judge lib:
1. ~~Some convenient overloads for the `TestCase` costructor. `condition ? 'Pass' : 'Fail'` is such a common pattern.~~
2. Type alias for the return type of the judge.
3. Rename of the `Code`class. It's not really code, is it? It's weird to write `code.code` everytime. A breaking change.
4. This point is not part of the PR but why do we need to wrap the final verdict in a class? I'd change it to be just
`FinalVerdict = boolean | "auto"` so that authors can just do `return false;` when they need to fail early. `return code.noFailures();` would turn into `return "auto";`, meaning the runner will just check if any of the yielded test cases fail and then fail based on that. Then you'd need no `.registerTestCase` which I keep forgetting to call and then wonder why the final verdict does not match the individual test cases.
5. Added some common challenge-building primitives: `range`, `rand`, `shuffle`.