### PR TITLE
Fix byte counter in EditorView

### DIFF
--- a/js/index.ts
+++ b/js/index.ts
@@ -56,19 +56,16 @@ const setupEditorControls = (editorControls: HTMLElement, mainTextArea: EditorVi
     const resetButton = editorControls.querySelector('#restore-solution-button')!;
     const textEncoder = new TextEncoder();
     const originalText = mainTextArea.state.doc.toString();
+    const lengthInBytes = (s: string): number => textEncoder.encode(s).length
 
-    byteCountElement.textContent = '' + textEncoder.encode(originalText).length;
+    byteCountElement.textContent = lengthInBytes(originalText).toString();
 
     mainTextArea.dispatch(
         {
             effects: StateEffect.appendConfig.of([
                 EditorView.updateListener.of((update) => {
                     if (update.docChanged) {
-                        byteCountElement.textContent = '' +
-                            [...mainTextArea.state.doc.iterLines()].reduce(
-                                (a, b) => a + textEncoder.encode(b).length + 1,
-                                0
-                            );
+                        byteCountElement.textContent = lengthInBytes(mainTextArea.state.doc.toString()).toString();
                     }
                 })
             ])


### PR DESCRIPTION
~~Line breaks were being counted twice by the old implementation~~

edit: Actually the count was just off by one. I thought line breaks were being counted twice because the count wasn't updated when the page was first loaded (so it correctly showed 0) but when I typed a single line break it jumped immediately to 2. In either case I think the new implementation is an improvement.