### PR TITLE
Hyperlink correction to stop forcing redirects

### DIFF
--- a/templates/home.html.jinja
+++ b/templates/home.html.jinja
@@ -33,7 +33,7 @@
       </p>
       <h2>Help or keep up with updates</h2>
       <p>
-        Consider joining <a href="https://discord.gg/ugbfdgzpjK">the Discord</a> or watching the project <a href="https://github.com/mousetail/yq">on GitHub</a>.
+        Consider joining the <a href="https://discord.gg/ugbfdgzpjK" target="_blank" rel="noopener">Discord</a> or watching the project on <a href="https://github.com/mousetail/Byte-Heist" target="_blank" rel="noopener">GitHub</a>.
         Pull requests very welcome.
       </p>
     </div>


### PR DESCRIPTION
Additionally, this'll open both hyperlinks in new tabs instead. Finally, `the` and `on` are moved out of the `<a>` tag, which is just weird otherwise.