### PR TITLE
Update `templates/base/base.html.jinja`

### DIFF
--- a/templates/base/base.html.jinja
+++ b/templates/base/base.html.jinja
@@ -65,13 +65,14 @@
     </main>
     <footer>
       <div class="footer-content">
-        <p>Copyright © 2024 Byte Heist. All rights reserved.</p>
+        <p>Copyright © 2024-2025 Byte Heist. All rights reserved.</p>
         <p>
           <a href="https://github.com/mousetail/Byte-Heist"
              alt="GitHub"
              title="GitHub"
              target="_blank"
-             rel="noopener">
+             rel="noopener"
+             style="text-decoration:none">
             <img src="/static/footer-icons/github.svg" alt="GitHub" title="GitHub" />
           </a>
           &nbsp;
@@ -79,7 +80,8 @@
              alt="Discord"
              title="Discord"
              target="_blank"
-             rel="noopener">
+             rel="noopener"
+             style="text-decoration:none">
             <img src="/static/footer-icons/discord.svg" alt="Discord" title="Discord" />
           </a>
         </p>


### PR DESCRIPTION
This commit addresses the footer by adding current year, and applies `style="text-decoration:none"` to both `<a>` tags. Whoever formatted the code must not have noticed the hyperlink underlining sticking out of the GitHub icon.

![image](https://github.com/user-attachments/assets/ebcfd2b9-2233-419b-a20d-88576dd0bc7e)