### PR TITLE
New postmortem layout and improved styling

### DIFF
--- a/js/style.css
+++ b/js/style.css
@@ -417,11 +417,42 @@ button {
   vertical-align: middle;
 }
 
-.horizontal-dl {
+.post-mortem-solution {
+  display: flex;
+  align-items: center;
+  background-color: #b9edd4;
+  margin: 0.6ch;
+  flex-wrap: wrap;
+  & pre {
+    min-width: 15ch;
+    margin: 0.6rem;
+    flex-grow: 1;
+  }
+}
+
+.post-mortem-solution.post-mortem {
+  background-color: #dee9e3;
+}
+
+.solution-metadata {
   display: flex;
   justify-content: space-between;
-
-  & dt {
-    font-weight: bold;
+  margin: 0.6rem;
+  & dl {
+    display: grid;
+    grid-template-columns: 12ch 1fr;
+    & dt {
+      width: 11ch;
+      white-space: pre;
+      font-weight: bold;
+    }
+    & dd {
+      min-width: 20ch;
+      & a {
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
+      }
+    }
   }
 }

--- a/templates/post_mortem_view.html.jinja
+++ b/templates/post_mortem_view.html.jinja
@@ -19,31 +19,24 @@
     {% endfor %}
   </div>
   {% for solution in object.solutions %}
-    <div class="post-mortem-solution">
-      {% if solution.code %}<pre class="code-pre code-pre-short">{{ solution.code }}</pre>{% endif %}
-      <div class="horizontal-dl">
-        <div>
-          <dt>Runtime</dt>
+    <div class="post-mortem-solution {% if solution.is_post_mortem %}post-mortem{% endif %}">
+      <div class="solution-metadata">
+        <dl>
+          <dt>Author</dt>
           <dd>
-            {{ solution.runtime }}
+            <a href="/user/{{ solution.author_id }}">
+              <img src="{{ solution.author_avatar }}" width="32" alt="">
+              <span>{{ solution.author_name }}</span>
+            </a>
           </dd>
-        </div>
-        <div>
           <dt>Score</dt>
           <dd>
             {{ solution.score }}
           </dd>
-        </div>
-        <div>
-          <dt>Author</dt>
+          <dt>Runtime</dt>
           <dd>
-            <a href="/user/{{ solution.author_id }}">
-              {{ solution.author_name }}
-              <img src="{{ solution.author_avatar }}" width="32" alt="">
-            </a>
+            {{ 1000 * solution.runtime | round }} ms
           </dd>
-        </div>
-        <div>
           <dt>Valid</dt>
           <dd>
             {% if solution.valid %}
@@ -52,8 +45,6 @@
               False
             {% endif %}
           </dd>
-        </div>
-        <div>
           <dt>Post Mortem</dt>
           <dd>
             {% if solution.is_post_mortem %}
@@ -62,8 +53,9 @@
               False
             {% endif %}
           </dd>
-        </div>
+        </dl>
       </div>
+      {% if solution.code %}<pre class="code-pre code-pre-short">{{ solution.code }}</pre>{% endif %}
     </div>
   {% endfor %}
 {% endblock content %}


### PR DESCRIPTION
Should look something like this (pay no attention to my bad test data):
![image](https://github.com/user-attachments/assets/82325e41-a237-47a5-b75c-2469c9009f9d)

If the code can't fit next to the metadata it will wrap (which is important to make the layout work better on mobile):
![image](https://github.com/user-attachments/assets/956704f9-db34-4b1c-ba78-c491d42ed723)

Post mortem submissions have a different background color (as suggested by Luke on Discord).