### PR TITLE
Codemirror plugins from code.golf

### DIFF
--- a/js/code_editor.ts
+++ b/js/code_editor.ts
@@ -1,7 +1,7 @@
 import { basicSetup, EditorView, minimalSetup } from "codemirror";
 import { keymap } from "@codemirror/view";
 import { indentWithTab } from "@codemirror/commands";
-import { Compartment } from "@codemirror/state";
+import { Compartment, Prec } from "@codemirror/state";
 import { javascript } from "@codemirror/lang-javascript";
 import { indentUnit } from "@codemirror/language";
 import { autocompletion } from "@codemirror/autocomplete";
@@ -10,6 +10,8 @@ import * as Comlink from "comlink";
 import { StateEffect } from "@codemirror/state";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { basicLight } from "@fsegurai/codemirror-theme-basic-light";
+
+import { carriageReturn, insertChar, insertCharState } from './code_editor_plugins'; 
 
 let typeScriptEnvironment: WorkerShape | undefined = undefined;
 
@@ -93,6 +95,9 @@ export function createCodemirrorFromTextAreas(): EditorView | undefined {
       indentUnit.of("\t"),
       editorTheme.of(getTheme()),
       EditorView.lineWrapping,
+      insertChar,
+      insertCharState,
+      Prec.high(carriageReturn), // Increased precedence so it overrides the default shift-enter keybinding
     ];
     console.log("Replacing textarea with codemirror");
     let view = editorFromTextArea(

--- a/js/code_editor.ts
+++ b/js/code_editor.ts
@@ -11,7 +11,7 @@ import { StateEffect } from "@codemirror/state";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { basicLight } from "@fsegurai/codemirror-theme-basic-light";
 
-import { carriageReturn, insertChar, insertCharState } from './code_editor_plugins'; 
+import { carriageReturn, insertChar, insertCharState, showUnprintables } from './code_editor_plugins';
 
 let typeScriptEnvironment: WorkerShape | undefined = undefined;
 
@@ -95,9 +95,11 @@ export function createCodemirrorFromTextAreas(): EditorView | undefined {
       indentUnit.of("\t"),
       editorTheme.of(getTheme()),
       EditorView.lineWrapping,
+
       insertChar,
       insertCharState,
-      Prec.high(carriageReturn), // Increased precedence so it overrides the default shift-enter keybinding
+      Prec.high(showUnprintables), // Increased precedence to override unprintable char printing in basicSetup
+      Prec.high(carriageReturn), // Increased precedence to override shift-enter key binding in basicSetup
     ];
     console.log("Replacing textarea with codemirror");
     let view = editorFromTextArea(

--- a/js/code_editor_plugins.ts
+++ b/js/code_editor_plugins.ts
@@ -1,0 +1,126 @@
+// Taken from https://github.com/code-golf/code-golf/blob/8a5b77b4c6f796336d9ad2858f260fb18d269dff/js/_codemirror_unprintable.tsx
+
+import { Decoration, EditorView, keymap, MatchDecorator, Panel, ViewPlugin, WidgetType, showPanel } from '@codemirror/view';
+import { EditorState, StateEffect, StateField } from '@codemirror/state';
+
+export const carriageReturn = [
+    EditorState.lineSeparator.of('\n'), // Prevent CM from treating carriage return as newline
+    keymap.of({
+        key: 'Shift-Enter',
+        run: ({ state, dispatch }: any) => {
+            dispatch(state.replaceSelection('\r'));
+            return true;
+        },
+    } as any),
+    /* When all the newlines inserted in a transaction are preceded by a
+    carriage return, remove the carriage returns. This fixes lines ending
+    with a carriage return when copied and pasted on Windows. */
+    EditorState.transactionFilter.of(transaction => {
+        const changes: {from: number, to: number}[] = [];
+        let allPrefixed = true;
+        transaction.changes.iterChanges((fromA, toA, fromB, toB, inserted) => {
+            if (!allPrefixed)
+                return;
+            const string = inserted.sliceString(0);
+            for (let i = 0; (i = string.indexOf('\n', i)) >= 0; i++) {
+                if (string[i - 1] != '\r') {
+                    allPrefixed = false;
+                    return;
+                }
+                changes.push({ from: fromB + i - 1, to: fromB + i });
+            }
+        });
+        return allPrefixed ? [transaction, { changes, sequential: true }] : transaction;
+    }),
+];
+
+interface InsertCharState {
+    code?: string;
+    toggleMode?: boolean;
+}
+
+const updateInsertCharState = StateEffect.define<string | boolean>();
+export const insertCharState = StateField.define<InsertCharState>({
+    create: () => ({}),
+    update(value, tr) {
+        if (tr.docChanged) value = {};
+        for (const e of tr.effects) {
+            if (!e.is(updateInsertCharState)) continue;
+            if (e.value === true) {
+                value = { ...value, toggleMode: true };
+            }
+            else if (e.value === false) {
+                value = {};
+            }
+            else {
+                value = { ...value, code: (value.code || '') + e.value };
+            }
+        }
+        return value;
+    },
+    provide: f => showPanel.from(f, value => value.code !== undefined ? createPanel : null),
+});
+
+const createPanel = (): Panel => {
+    const dom = document.createElement('div');
+    return {
+        dom,
+        update(update) {
+            const { code, toggleMode } = update.state.field(insertCharState);
+            const toggleModeHelp = toggleMode ? ' (press Alt again to insert)' : '';
+            if (code) {
+                dom.textContent = 'Composing \\u' + code + '...' + toggleModeHelp;
+            }
+            else if (toggleMode) {
+                dom.textContent = 'Type hexadecimal digits and press Alt again to insert.';
+            }
+            else {
+                dom.textContent = '';
+            }
+        },
+    };
+};
+
+export const insertChar = EditorView.domEventHandlers({
+    keydown: (event, view) => {
+        const hasOtherMods = event.ctrlKey || event.shiftKey || event.metaKey;
+
+        if (event.key == 'Alt' && !hasOtherMods) {
+            // This might be a toggle start, so we start buffering keys.
+            view.dispatch({ effects: updateInsertCharState.of('')});
+            event.preventDefault();
+            return;
+        }
+
+        const { code, toggleMode } = view.state.field(insertCharState);
+        if ((event.altKey || toggleMode) && !hasOtherMods && event.key.match(/^[0-9a-f]$/i)) {
+            view.dispatch({ effects: updateInsertCharState.of(event.key.toUpperCase()) });
+            event.preventDefault();
+        }
+        else if (code || toggleMode) {
+            // Reset the state whenever possible.
+            view.dispatch({ effects: updateInsertCharState.of(false) });
+        }
+    },
+
+    keyup: (event, view) => {
+        if (event.key != 'Alt') return;
+
+        const { code, toggleMode } = view.state.field(insertCharState);
+        if (code === '' && !toggleMode) {
+            view.dispatch({ effects: updateInsertCharState.of(true) });
+            return;
+        }
+
+        let codepoint;
+        try {
+            if (code) codepoint = String.fromCodePoint(parseInt(code, 16));
+        }
+        catch {}
+
+        view.dispatch(
+            { effects: updateInsertCharState.of(false) },
+            codepoint ? view.state.replaceSelection(codepoint) : {},
+        );
+    },
+});

--- a/js/code_editor_plugins.ts
+++ b/js/code_editor_plugins.ts
@@ -2,6 +2,7 @@
 
 import { Decoration, EditorView, keymap, MatchDecorator, Panel, ViewPlugin, WidgetType, showPanel } from '@codemirror/view';
 import { EditorState, StateEffect, StateField } from '@codemirror/state';
+import UnprintableElement from './unprintable';
 
 export const carriageReturn = [
     EditorState.lineSeparator.of('\n'), // Prevent CM from treating carriage return as newline
@@ -124,3 +125,37 @@ export const insertChar = EditorView.domEventHandlers({
         );
     },
 });
+
+class UnprintableWidget extends WidgetType {
+    value;
+
+    constructor(value: number) {
+        super();
+        this.value = value;
+    }
+    toDOM() {
+        const el = new UnprintableElement();
+        el.setAttribute('c', String.fromCharCode(this.value));
+        return el;
+    }
+}
+
+const unprintableDecorator = new MatchDecorator({
+    regexp: UnprintableElement.PATTERN,
+    decoration: match => Decoration.replace({
+        widget: new UnprintableWidget(match[0].charCodeAt(0)),
+    }),
+});
+
+export const showUnprintables = ViewPlugin.fromClass(
+    class {
+        decorations;
+        constructor(view: any) {
+            this.decorations = unprintableDecorator.createDeco(view);
+        }
+        update(update: any) {
+            this.decorations = unprintableDecorator.updateDeco(update, this.decorations);
+        }
+    },
+    { decorations: plugin => plugin.decorations },
+);

--- a/js/style.css
+++ b/js/style.css
@@ -182,6 +182,10 @@ textarea:focus-within {
   border: 1px solid #27534a;
 }
 
+.cm-panels {
+  margin-top: auto;
+}
+
 .test-pass {
   background-color: #7dca8c;
 }

--- a/js/unprintable.ts
+++ b/js/unprintable.ts
@@ -1,0 +1,115 @@
+import { StyleModule } from 'style-mod'; // Already used by CodeMirror
+
+/* eslint no-unused-vars: ["off"] */
+
+const shadowStyle = new StyleModule({
+    ':host': {
+        display: 'inline-block',
+        position: 'relative',
+        verticalAlign: 'middle',
+        width: '1ch',
+        height: '1em',
+        // Omit emoji because Apple Color Emoji has a full-width glyph for non-emoji '0'. (???)
+        fontFamily: "'Source Code Pro', monospace",
+        lineHeight: 0.8,
+        cursor: 'text',
+    },
+    ':host > span': {
+        'WebkitTextFillColor': 'transparent',
+        '&:before, &:after': {
+            WebkitTextFillColor: 'currentcolor',
+            fontSize: '70%',
+            position: 'absolute',
+            pointerEvents: 'none',
+        },
+        '&:before': {
+            content: 'attr(data-h)',
+            left: 0,
+            top: 0,
+        },
+        '&:after': {
+            content: 'attr(data-l)',
+            right: 0,
+            bottom: 0,
+        },
+    },
+
+    ':host([c])': {
+        pointerEvents: 'none',
+    },
+    ':host([c]) > span': {
+        pointerEvents: 'auto',
+    },
+});
+
+// <u-p>&#...;</u-p> renders a single character and allows selection and copying.
+// <u-p c="&#...;"></u-p> renders a single character but doesn't allow copying.
+//
+// TODO:
+// Title doesn't show up for the attribute use case in Safari and others.
+// Firefox doesn't (yet) let the selection cross shadow root boundaries. (cf. bug #1867058)
+export default class UnprintableElement extends HTMLElement {
+    #span;
+
+    constructor(text = '') {
+        super();
+
+        const shadow = this.attachShadow({ mode: 'closed' });
+        StyleModule.mount(shadow, shadowStyle);
+
+        this.#span = document.createElement('span');
+        shadow.append(this.#span);
+
+        if (text) this.textContent = text;
+    }
+
+    // For the simplicity, we only update the shadow DOM when connected.
+    connectedCallback() {
+        let c = this.getAttribute('c'), h, l, t;
+        const ignoreTextContent = !!c;
+        c = c || this.textContent || '';
+        if (c.length == 0) {
+            h = '⌜';
+            l = '⌟';
+            t = '(empty)';
+        }
+        else if (c.length == 1) {
+            const code = c.charCodeAt(0);
+            h = '0123456789ABCDEF'[code / 16 | 0];
+            l = '0123456789ABCDEF'[code % 16];
+            t = '\\u' + code.toString(16);
+        }
+        else {
+            h = '+';
+            l = '+';
+            c = '';
+            t = '(multiple)';
+        }
+        this.#span.setAttribute('data-h', h);
+        this.#span.setAttribute('data-l', l);
+        this.#span.textContent = ignoreTextContent ? '' : c;
+        this.#span.title = t;
+    }
+
+    static PATTERN = /([\x00-\x08\x0B-\x1F\x7F-\xA0])/g;
+
+    static escape(text: string): DocumentFragment {
+        const frag = document.createDocumentFragment();
+        const parts = text.split(UnprintableElement.PATTERN);
+        for (let i = 0; i < parts.length - 1; i += 2) {
+            frag.append(parts[i], new UnprintableElement(parts[i + 1]));
+        }
+        frag.append(parts[parts.length - 1]);
+        return frag;
+    }
+}
+
+customElements.define('u-p', UnprintableElement);
+
+declare global {
+    namespace JSX {
+        interface IntrinsicElements {
+            ['u-p']: any;
+        }
+    }
+}


### PR DESCRIPTION
- carriageReturn plugin
  - `Shift-Enter` inserts a `\r`
  - should remove `\r` from paste. I think this part is only relevant under windows and should allow removing the hacky workaround of counting `\r\n` as a single byte? (not near a windows system so didn't test)
- insertChar plugin
  - allows composing characters with ALT + hex + ALT
- showUnprintables plugin
  - better support for showing unprintables; mostly for the range `\x7f-\xA0` where the defaults result in the same char for the entire range