### PR TITLE
Send better escaped initial code for codemirror

### DIFF
--- a/js/code_editor.ts
+++ b/js/code_editor.ts
@@ -62,10 +62,11 @@ function getTheme() {
 
 function editorFromTextArea(
   textarea: HTMLTextAreaElement,
+  content: string,
   extensions: typeof minimalSetup,
   swapOnSubmit: boolean
 ): EditorView {
-  let view = new EditorView({ doc: textarea.value, extensions });
+  let view = new EditorView({ doc: content, extensions });
   textarea.parentNode?.insertBefore(view.dom, textarea);
   if (swapOnSubmit) {
     textarea.style.display = "none";
@@ -104,6 +105,7 @@ export function createCodemirrorFromTextAreas(): EditorView | undefined {
     console.log("Replacing textarea with codemirror");
     let view = editorFromTextArea(
       textarea,
+      window.originalSource,
       plugins,
       textarea.id !== "main-code"
     );

--- a/templates/challenge.html.jinja
+++ b/templates/challenge.html.jinja
@@ -9,7 +9,7 @@
 {% block scripts %}
   <script>
     {% if object.code %}
-      window.originalSource = {{ object.code | json_encode | safe }};
+      window.originalSource = decodeURIComponent("{{ object.code | urlencode_strict }}");
     {% else %}
       window.originalSource = "";
     {% endif %}

--- a/templates/challenge.html.jinja
+++ b/templates/challenge.html.jinja
@@ -6,6 +6,16 @@
   <link rel="canonical"
         href="https://byte-heist.com/challenge/{{ object.challenge.id }}/{{ object.challenge.name | slugify }}/solve/python">
 {% endblock head %}
+{% block scripts %}
+  <script>
+    {% if object.code %}
+      window.originalSource = {{ object.code | json_encode | safe }};
+    {% else %}
+      window.originalSource = "";
+    {% endif %}
+  </script>
+  {{ super() }}
+{% endblock scripts %}
 {% block content %}
   {{ challenge_tabs::challenge_tabs(active="solve", id=object.challenge.id, name=object.challenge.name, author=object.challenge.author) }}
   <h1>{{ object.challenge.name }}</h1>


### PR DESCRIPTION
Injects the initial code into a JavaScript variable that is used to initialize CodeMirror

An alternative approach would be to inject the code into a data attribute of the textarea. However, this would require escaping problematic characters (currently `\r`, with potentially others) beyond Tera's default escaping. I can revise the implementation to use this approach if preferred.