### PR TITLE
Split discord channels fix env vars

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # Do not put any production secrets into this file
 DATABASE_URL=postgresql://username:password@localhost:5432/default_database
 
-YQ_HOST=0.0.0.0
-YQ_PORT=3001
+BYTE_HEIST_HOST=0.0.0.0
+BYTE_HEIST_PORT=3001
 
-YQ_PUBLIC_URL=http://localhost:3001
+BYTE_HEIST_PUBLIC_URL=http://localhost:3001

--- a/discord-bot/src/lib.rs
+++ b/discord-bot/src/lib.rs
@@ -50,7 +50,7 @@ fn format_message(
     author: &BasicAccontInfo,
     last_best_score: &NewScore,
 ) -> CreateEmbed {
-    let public_url = std::env::var("YQ_PUBLIC_URL").unwrap();
+    let public_url = std::env::var("BYTE_HEIST_PUBLIC_URL").unwrap();
 
     CreateEmbed::new()
         .title(format!(

--- a/discord-bot/src/new_challenge.rs
+++ b/discord-bot/src/new_challenge.rs
@@ -27,7 +27,7 @@ fn gen_embed(
         scores,
     }: &NewChallengeEvent,
 ) -> CreateEmbed {
-    let public_url = std::env::var("YQ_PUBLIC_URL").unwrap();
+    let public_url = std::env::var("BYTE_HEIST_PUBLIC_URL").unwrap();
     CreateEmbed::new()
         .title(format!("New Challenge {challenge_name}"))
         .color(512)

--- a/lang-runner/Dockerfile
+++ b/lang-runner/Dockerfile
@@ -27,22 +27,22 @@ RUN apt-get update -y && apt-get install -y \
   # Vyxal Dependencies
   openjdk-17-jdk
 
-RUN adduser yq
+RUN adduser byte_heist
 
-USER yq
+USER byte_heist
 
 # Install asdf
 #RUN git clone --depth 1 https://github.com/asdf-vm/asdf.git ~/.asdf
-RUN curl -L https://github.com/asdf-vm/asdf/releases/download/v0.16.4/asdf-v0.16.4-linux-amd64.tar.gz -o /home/yq/asdf.tar.gz
+RUN curl -L https://github.com/asdf-vm/asdf/releases/download/v0.16.4/asdf-v0.16.4-linux-amd64.tar.gz -o /home/byte_heist/asdf.tar.gz
 RUN ls
 RUN mkdir -p ~/.bin
-RUN tar -xzf /home/yq/asdf.tar.gz -C ~/.bin
+RUN tar -xzf /home/byte_heist/asdf.tar.gz -C ~/.bin
 
 # Add asdf to PATH, so it can be run in this Dockerfile
-ENV PATH="$PATH:/home/yq/.bin"
+ENV PATH="$PATH:/home/byte_heist/.bin"
 
 # Add asdf shims to PATH, so installed executables can be run in this Dockerfile
-ENV PATH=$PATH:/home/yq/.asdf/shims
+ENV PATH=$PATH:/home/byte_heist/.asdf/shims
 
 COPY --from=rust-build /usr/src/myapp/target/release/lang-runner /lang-runner
 COPY ./scripts /scripts

--- a/lang-runner/src/run.rs
+++ b/lang-runner/src/run.rs
@@ -129,10 +129,10 @@ async fn run_lang(
             "--tmpfs",
             "/tmp",
             "--tmpfs",
-            "/home/yq",
+            "/home/byte_heist",
             "--setenv",
             "HOME",
-            "/home/yq",
+            "/home/byte_heist",
         ])
         .args(["--ro-bind"])
         .arg(code_lang_folder)

--- a/main-server/src/controllers/auth.rs
+++ b/main-server/src/controllers/auth.rs
@@ -121,7 +121,10 @@ pub async fn github_callback(
         .get("https://api.github.com/user")
         .header("Accept", "application/vnd.github+json")
         .header("X-GitHub-Api-Version", "2022-11-28")
-        .header("User-Agent", "Rust-Reqwest (Byte-Heist)")
+        .header(
+            "User-Agent",
+            "Rust-Reqwest (Byte Heist https://byte-heist.com)",
+        )
         .bearer_auth(token.secret())
         .send()
         .await

--- a/main-server/src/controllers/auth.rs
+++ b/main-server/src/controllers/auth.rs
@@ -45,7 +45,8 @@ fn create_github_client(
         .set_redirect_uri(
             RedirectUrl::new(format!(
                 "{}/callback/github",
-                env::var("YQ_PUBLIC_URL").expect("Missing the YQ_PUBLIC_URL environment variable")
+                env::var("BYTE_HEIST_PUBLIC_URL")
+                    .expect("Missing the BYTE_HEIST_PUBLIC_URL environment variable")
             ))
             .expect("Invalid redirect URL"),
         )
@@ -120,7 +121,7 @@ pub async fn github_callback(
         .get("https://api.github.com/user")
         .header("Accept", "application/vnd.github+json")
         .header("X-GitHub-Api-Version", "2022-11-28")
-        .header("User-Agent", "Rust-Reqwest (YQ)")
+        .header("User-Agent", "Rust-Reqwest (Byte-Heist)")
         .bearer_auth(token.secret())
         .send()
         .await

--- a/main-server/src/main.rs
+++ b/main-server/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> anyhow::Result<()> {
     let session_layer = SessionManagerLayer::new(session_store.clone())
         .with_secure(false)
         .with_same_site(tower_sessions::cookie::SameSite::Lax)
-        .with_name("yq_session_store_id")
+        .with_name("byte_heist_session_store_id")
         .with_expiry(Expiry::OnInactivity(
             tower_sessions::cookie::time::Duration::days(360),
         ));
@@ -163,8 +163,8 @@ async fn main() -> anyhow::Result<()> {
 
     let listener = tokio::net::TcpListener::bind(&format!(
         "{}:{}",
-        env::var("YQ_HOST").expect("Expcted YQ_HOST var to be set"),
-        env::var("YQ_PORT").expect("Excpected YQ_PORT var to be set")
+        env::var("BYTE_HEIST_HOST").expect("Expcted BYTE_HEIST_HOST var to be set"),
+        env::var("BYTE_HEIST_PORT").expect("Excpected BYTE_HEIST_PORT var to be set")
     ))
     .await
     .unwrap();


### PR DESCRIPTION
Splits the new challenges into two channels:
- New golfers
- New challenges

Also renamed env vars and username in the dockerfile to not reference YQ anymore.