### PR TITLE
Cut off challenge descriptions on home page less awkwardly

### DIFF
--- a/main-server/src/models/challenge.rs
+++ b/main-server/src/models/challenge.rs
@@ -201,7 +201,7 @@ impl HomePageChallenge {
                 name,
                 category as "category!: ChallengeCategory",
                 scores.score,
-                CAST(description AS varchar(60)) as "description!",
+                CAST(description AS varchar(120)) as "description!",
                 post_mortem_date
             FROM challenges
             LEFT JOIN scores ON scores.author = $2 AND scores.challenge = challenges.id AND scores.language = $3

--- a/templates/base/home_page_challenge.html.jinja
+++ b/templates/base/home_page_challenge.html.jinja
@@ -6,7 +6,7 @@
                 <h3 class="font-bold text-white">{{ challenge.name }}</h3>
                 {# Optionally, add an icon here if available: <img src="..." alt="..." /> #}
             </div>
-            <p class="text-sm text-byte-brown-200 flex-grow">
+            <p class="text-sm text-byte-brown-200 flex-grow line-clamp-2">
                 {{ challenge.description | default(value="No description provided.") }}
             </p>
             <div class="flex flex-col gap-2 mt-4">


### PR DESCRIPTION
This should make the challenges on home page look more like the one on the left and less like the one on the right in the below screenshot:

<img width="751" height="185" alt="screenshot of two challenges on home page" src="https://github.com/user-attachments/assets/d4d1579e-c315-477b-8151-467ea48c11bd" />

It would also be nice to strip any possible markdown formatting but I didn't do that yet as it seems a bit more complicated, and you'd probably need to fetch much more of the description from the database to make eg. [missing first](https://byte-heist.com/challenge/39/missing-first/solve/python) description which has a link near the beginning render properly.