### PR TITLE
Pin postgres version to 17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ./scripts:/scripts
     entrypoint: ["/scripts/auto-reload.sh", "/debug/lang-runner"]
   postgres:
-    image: "postgres:latest"
+    image: "postgres:17"
     ports:
       - 5432:5432
     environment:


### PR DESCRIPTION
Pins postgres to version 17. Relevant breaking change: https://github.com/docker-library/postgres/pull/1259