### PR TITLE
Add "joke" for Vyxal 1000 Point Achievement

### DIFF
--- a/common/src/achievements.rs
+++ b/common/src/achievements.rs
@@ -104,7 +104,7 @@ impl AchievementType {
             AchievementType::JavaScript1000Point => "Node Nerd",
             AchievementType::JavaScript3500Point => "Node Narcissist",
             AchievementType::Rust1000Point => "Crab Rave",
-            AchievementType::Vyxal1000Point => "[Insert Joke Here]",
+            AchievementType::Vyxal1000Point => "Absolute Gamer",
             AchievementType::C1000Point => "Deep Blue Sea",
             AchievementType::Apl1000Point => "Original Sin",
             AchievementType::StarTheRepo => "Starstruck",


### PR DESCRIPTION
The joke is multilayered:

1. "Gamers" is a term we've used in the Vyxal community in the past to describe members (e.g. the github org description has "A group of epic gamers who work on Vyxal")
2. It's a play on the "Absolute Cinema" meme.

I considered more "clever" or "on the nose" choices, but I think this is very apt.